### PR TITLE
Refactor: Replace 'Connect Wallet' button with Stripe link

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Header with Wallet Connect -->
     <header>
         <div class="logo">THE SMOKE STREAM</div>
-        <button id="connect-wallet-btn">Connect Wallet</button>
+        <a href="https://buy.stripe.com/8wM6px5ycf9pgfK000" target="_blank" rel="noopener noreferrer" id="connect-wallet-btn" class="">Connect Wallet</a>
     </header>
 
     <!-- Section 1: Hero with Video Background -->

--- a/script.js
+++ b/script.js
@@ -11,44 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const audioVisualizer = document.getElementById('audio-visualizer');
 
     // New Web3 Elements
-    const connectWalletBtn = document.getElementById('connect-wallet-btn');
     const gatedItems = document.querySelectorAll('.gated-item');
-
-    // --- Wallet Connection Logic (Simulation) ---
-    let walletConnected = false;
-
-    connectWalletBtn.addEventListener('click', () => {
-        if (walletConnected) {
-            // Simulate disconnect
-            walletConnected = false;
-            connectWalletBtn.textContent = 'Connect Wallet';
-            connectWalletBtn.style.backgroundColor = 'var(--primary-color)';
-            lockAllItems();
-        } else {
-            // Simulate connect
-            walletConnected = true;
-            connectWalletBtn.textContent = 'Wallet Connected';
-            connectWalletBtn.style.backgroundColor = 'var(--secondary-color)';
-            unlockAllItems();
-        }
-    });
-
-    function lockAllItems() {
-        gatedItems.forEach(item => {
-            const lockStatus = item.querySelector('.lock-status');
-            lockStatus.textContent = 'LOCKED';
-            lockStatus.classList.remove('unlocked');
-        });
-    }
-
-    function unlockAllItems() {
-        gatedItems.forEach(item => {
-            const lockStatus = item.querySelector('.lock-status');
-            lockStatus.textContent = 'UNLOCKED';
-            lockStatus.classList.add('unlocked');
-        });
-    }
-
 
     // --- Existing Logic ---
 


### PR DESCRIPTION
The 'Connect Wallet' button in the header, which previously simulated a wallet connection, has been changed to a direct link to a Stripe payment page.

Changes:
- Modified `index.html`:
    - Changed the `<button id="connect-wallet-btn">` to an `<a id="connect-wallet-btn">`.
    - Set the `href` attribute to `https://buy.stripe.com/8wM6px5ycf9pgfK000`.
    - Added `target="_blank"` and `rel="noopener noreferrer"` for better user experience and security.
- Modified `script.js`:
    - Removed the `connectWalletBtn` constant.
    - Removed the associated event listener for the button.
    - Removed the `walletConnected` variable.
    - Removed the `lockAllItems` and `unlockAllItems` functions as they were triggered by the old button's simulated connection state and are no longer needed.

This change directly addresses the issue by replacing the mock wallet functionality with the requested Stripe sign-up link.